### PR TITLE
fix: bring back Dockerfile formatting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,9 @@
     "customizations": {
         "vscode": {
             "settings": {
+                "[dockerfile]": {
+                    "editor.defaultFormatter": "ms-azuretools.vscode-containers"
+                },
                 "files.insertFinalNewline": true,
                 "files.trimFinalNewlines": true,
                 "files.trimTrailingWhitespace": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "[dockerfile]": {
+        "editor.defaultFormatter": "ms-azuretools.vscode-containers"
+    },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "files.trimTrailingWhitespace": true


### PR DESCRIPTION
Apparently, the `ms-azuretools.vscode-containers` extension does format Dockerfiles after all. Add the required settings to the repo's vscode settings to enable it.
