### PR TITLE
fix: bad substitution in cleanup.yml

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Delete untagged images
         uses: actions/delete-package-versions@v5
         with:
-          package-name: ${{ github.event.repository.name }}
+          package-name: ${{ github.repository }}
           package-type: container
           delete-only-untagged-versions: true
           min-versions-to-keep: 0


### PR DESCRIPTION
The substitution should've been `${{ github.repository }}`, not the event name.
